### PR TITLE
OAS generator, README , and navbar link to swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# A RESTful API
+
+## Setup 
+
+- `npm install`
+
+## Launch
+
+- `npm run start`
+
+## Access the Swagger/OpenAPI UI
+
+- [localhost:3000/api-docs/v3/](http://localhost:3000/api-docs/v3/)

--- a/app.js
+++ b/app.js
@@ -4,8 +4,7 @@ const morgan = require('morgan');         // Log every request to the console
 require('dotenv').config();              // Import dotenv to use .env file
 const routes = require('./routes/routes.js');  // Import routes.js
 
-
-
+const expressOasGenerator = require('express-oas-generator');
 
 const port = process.env.PORT || 3000;       // Import the variable PORT from .env
 const localhost = process.env.LOCALHOST || 'localhost';   // Import the variable LOCALHOST from .env
@@ -16,6 +15,13 @@ app.use(express.json());  // parse requests of content-type - application/json
 app.use('/', routes);          // Use routes.js
 app.use(express.static('public')); // Servir archivos estáticos desde la carpeta 'public'
 
+/** place handleResponses as the very first middleware */
+expressOasGenerator.handleResponses(app, {});
+
+/** initialize your `app` and routes */
+
+/** place handleRequests as the very last middleware */
+expressOasGenerator.handleRequests();
 
 app.listen(port, localhost, () => {
   console.log(`server listening on ${port} on ${localhost}`)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "dotenv": "^16.1.4",
     "express": "^4.18.2",
+    "express-oas-generator": "^1.0.46",
     "morgan": "^1.10.0",
     "nodemon": "^2.0.22"
   }

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
   <header class="navbar">
         <nav class="links">
           <ul>
+            <li><a  href="/api-docs/v3">Swagger</a></li>
             <li><a  href="/api/links">Links</a></li>
             <li><a  href="/api/data">Data</a></li>
             <li><a href="/api/protected_areas">Protected Areas</a></li>


### PR DESCRIPTION
could not see the swagger interface.

Another way to provide the schema is via code annotation, [good read](https://apisyouwonthate.com/blog/theres-no-reason-to-write-openapi-by-hand/)