### PR TITLE
adds TODOs for improvement in the getCode route function

### DIFF
--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -28,7 +28,8 @@ const getCountries = async (req, res) => {
 
     const { data, error } = await supabase
         .from("countries")
-        .select("*");
+        .select("*"); // TODO select fields
+        // TODO add ordering?
 
     res.json(data);
 };
@@ -40,10 +41,16 @@ const getCodes = async (req, res) => {
     let { data, error } = await supabase
         .from('countries')
         .select('Code')
+        // TODO add  .limit, with very large data is will blow up the server memory
+        // TODO add ordering?
 
+    // TODO make use of error 5 lines above, if error, then throw an error code to the consumer
+    
     // Maps the data and extract the Codes removing duplicates
     const codes = [];
+    // TODO null check on `data`
     data.forEach(entry => {
+
         if (!codes.includes(entry.Code)) {
             codes.push(entry.Code);
         }


### PR DESCRIPTION
Just some TODOs to consider...

- Adding LIMIT to queries by default isn't for pagination here, just as a defence against so much data, it won't just consume huge memory, it will likely crash the server
- When some I/O call is made, e.g talking to a remote DB, disk, 3rd party services, always handle errors as I/O is beyond the server control.

Regarding:
```
    // Maps the data and extract the Codes removing duplicates
```

It's generally far more efficient and less bug prompt to let the DB do that. It does it better, and won't break LIMIT/pagination.
clauses such as GROUP BY should do the trick.

but supabase/postgres is superb: `skipDuplicates` on inserts